### PR TITLE
Account for EOF from read()

### DIFF
--- a/src/unix/async.c
+++ b/src/unix/async.c
@@ -131,7 +131,7 @@ static void uv__async_io(uv_loop_t* loop, uv__io_t* w, unsigned int events) {
   wa = container_of(w, struct uv__async, io_watcher);
 
 #if defined(__linux__)
-  if (wa->wfd == -1) {
+  if (wa->wfd == -1 && n != 0) {
     uint64_t val;
     assert(n == sizeof(val));
     memcpy(&val, buf, sizeof(val));  /* Avoid alignment issues. */


### PR DESCRIPTION
Suggested fix for issue:  https://github.com/libuv/libuv/issues/1171

Don't assert() when n=0 after read() call

